### PR TITLE
Added checking for invalid characters in file names for Windows

### DIFF
--- a/src/minio.ts
+++ b/src/minio.ts
@@ -230,7 +230,7 @@ export default class MinIO {
     ): Promise<void> {
         try {
             if (win) {
-                const baseName = path.basename(objectName);
+                const baseName = path.basename(filePath);
                 const dirPath = path.dirname(filePath);
                 const dirs: string[] = dirPath.split(path.sep);
                 for (const dir of dirs) {

--- a/src/minio.ts
+++ b/src/minio.ts
@@ -224,11 +224,17 @@ export default class MinIO {
         filePath: string
     ): Promise<void> {
         try {
-            objectName = ProcessObjectName(objectName);
-            await this.client.fGetObject(this.bucket, objectName, filePath);
-            Log(
-                `File downloaded successfully from ${this.bucket}/${objectName}`
-            );
+            const invalidChar = /.*[\/\\].*[\:\<\>\*\?\|]+.*$/.test(objectName);
+            const isWin = os.platform() == "win32";
+            if (invalidChar && isWin) {
+                Log(`File name contains invalid characters: ${objectName}`);
+            } else {
+                objectName = ProcessObjectName(objectName);
+                await this.client.fGetObject(this.bucket, objectName, filePath);
+                Log(
+                    `File downloaded successfully from ${this.bucket}/${objectName}`
+                );
+            }
         } catch (error) {
             console.error("Error downloading file:", error);
             throw error;

--- a/src/minio.ts
+++ b/src/minio.ts
@@ -1,12 +1,9 @@
 import * as fs from "fs-extra";
 import * as minio from "minio";
-import * as os from "os";
+import os from "os";
 import path from "path";
 import { ObjectEvent, TObjectsListener } from "./manager";
 import { CalcEtag, Log, TObjItem } from "./utils";
-
-const win = os.platform() === "win32";
-
 export interface IMinIOConfig {
     Bucket: string;
     ListenUpdates: boolean;
@@ -52,6 +49,7 @@ const ToManagerObjEvent: Record<string, ObjectEvent> = {
 const WinInvalidChars = /[<>:"\/\\|?*]/;
 
 export default class MinIO {
+    private win: boolean = os.platform() === "win32";
     private client: minio.Client;
     private bucket: string;
     private objects = new Map<string, TObjItem>();
@@ -229,7 +227,7 @@ export default class MinIO {
         filePath: string
     ): Promise<void> {
         try {
-            if (win) {
+            if (this.win) {
                 const baseName = path.basename(filePath);
                 const dirPath = path.dirname(filePath);
                 const dirs: string[] = dirPath.split(path.sep);
@@ -294,6 +292,8 @@ export default class MinIO {
         return result;
     }
 }
+
+const win = os.platform() === "win32";
 
 export function ProcessObjectName(objectName: string): string {
     let result = win ? objectName.replace(/\\/g, "/") : objectName; // Deduplicate \\ in objectName in case of Windows and replace \ with /

--- a/src/minio.ts
+++ b/src/minio.ts
@@ -5,6 +5,8 @@ import path from "path";
 import { ObjectEvent, TObjectsListener } from "./manager";
 import { CalcEtag, Log, TObjItem } from "./utils";
 
+const win = os.platform() === "win32";
+
 export interface IMinIOConfig {
     Bucket: string;
     ListenUpdates: boolean;
@@ -227,7 +229,7 @@ export default class MinIO {
         filePath: string
     ): Promise<void> {
         try {
-            if (os.platform() == "win32") {
+            if (win) {
                 const baseName = path.basename(objectName);
                 const dirPath = path.dirname(filePath);
                 const dirs: string[] = dirPath.split(path.sep);
@@ -292,8 +294,6 @@ export default class MinIO {
         return result;
     }
 }
-
-const win = os.platform() === "win32";
 
 export function ProcessObjectName(objectName: string): string {
     let result = win ? objectName.replace(/\\/g, "/") : objectName; // Deduplicate \\ in objectName in case of Windows and replace \ with /


### PR DESCRIPTION
### Description of change

Added checking of file names before downloading using the regular expression `/.*[\/\\].*[\:\<\>\*\?\|]+.*$/` for Windows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved file download validation for Windows systems.
	- Added character validation to prevent downloading files with invalid names.
	- Enhanced error logging for file download processes.
- **Tests**
	- Introduced a new test suite for validating the file download functionality on Windows.
	- Added tests for logging errors related to invalid characters in file and directory names.
	- Included a test case to ensure successful file downloads when valid names are used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->